### PR TITLE
fix: 修复增量同步时的类型转换问题

### DIFF
--- a/dbt/include/maxcompute/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/maxcompute/macros/materializations/incremental/incremental.sql
@@ -59,16 +59,16 @@
         {{ create_table_as_internal(False, target_relation, sql, True, partition_config=partition_by) }}
       {%- endcall -%}
   {% else %}
-    {% set tmp_relation_exists = false %}
+    {% set temp_relation_exists = false %}
     {% if on_schema_change != 'ignore' %}
       {#-- Check first, since otherwise we may not build a temp table --#}
       {#-- Python always needs to create a temp table --#}
-      {%- call statement('create_tmp_relation') -%}
-        {{ create_table_as_internal(True, tmp_relation, sql, True, partition_config=partition_by) }}
+      {%- call statement('create_temp_relation') -%}
+        {{ create_table_as_internal(True, temp_relation, sql, True, partition_config=partition_by) }}
       {%- endcall -%}
-      {% set tmp_relation_exists = true %}
+      {% set temp_relation_exists = true %}
       {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
-      {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
+      {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}
     {% endif %}
 
     {% if not dest_columns %}
@@ -76,7 +76,7 @@
     {% endif %}
 
     {% set build_sql = mc_generate_incremental_build_sql(
-        incremental_strategy, temp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, tmp_relation_exists, incremental_predicates
+        incremental_strategy, temp_relation, target_relation, sql, unique_key, partition_by, partitions, dest_columns, temp_relation_exists, incremental_predicates
     ) %}
 
     {% call statement("main") %}

--- a/dbt/include/maxcompute/macros/utils/date_spine.sql
+++ b/dbt/include/maxcompute/macros/utils/date_spine.sql
@@ -113,7 +113,7 @@
 
         select *
         from all_periods
-        where datediff(date_{{datepart}}, {{ end_date }}) <= 0
+        where cast(date_{{datepart}} as timestamp) <= cast({{ end_date }} as timestamp)
 
     )
 


### PR DESCRIPTION
close issue https://github.com/aliyun/dbt-maxcompute/issues/6
- 将 date_spine.sql 中的 datediff 函数替换为 timestamp 类型比较
- 修改 incremental.sql 中的临时表名称和相关变量名称